### PR TITLE
Simplify login to password only

### DIFF
--- a/__tests__/playwright-test/tests/login.spec.ts
+++ b/__tests__/playwright-test/tests/login.spec.ts
@@ -9,8 +9,6 @@ test('start chatting is displayed', async ({ page }) => {
 
 test('No password error message', async ({ page }) => {
   await page.goto('http://localhost:3000/login');
-  //fill in dummy email
-  await page.getByPlaceholder('you@example.com').fill('dummyemail@gmail.com');
   await page.getByRole('button', { name: 'Login' }).click();
   //wait for netwrok to be idle
   await page.waitForLoadState('networkidle');
@@ -20,27 +18,9 @@ test('No password error message', async ({ page }) => {
 });
 test('No password for signup', async ({ page }) => {
   await page.goto('http://localhost:3000/login');
-  
-  await page.getByPlaceholder('you@example.com').fill('dummyEmail@Gmail.com');
   await page.getByRole('button', { name: 'Sign Up' }).click();
   //validate appropriate error is thrown for missing password when signing up
   await expect(page.getByText('Signup requires a valid')).toBeVisible();
-});
-test('invalid username for signup', async ({ page }) => {
-  await page.goto('http://localhost:3000/login');
-  
-  await page.getByPlaceholder('you@example.com').fill('dummyEmail');
-  await page.getByPlaceholder('••••••••').fill('dummypassword');
-  await page.getByRole('button', { name: 'Sign Up' }).click();
-  //validate appropriate error is thrown for invalid username when signing up
-  await expect(page.getByText('Unable to validate email')).toBeVisible();
-});
-test('password reset message', async ({ page }) => {
-  await page.goto('http://localhost:3000/login');
-  await page.getByPlaceholder('you@example.com').fill('demo@gmail.com');
-  await page.getByRole('button', { name: 'Reset' }).click();
-  //validate appropriate message is shown
-  await expect(page.getByText('Check email to reset password')).toBeVisible();
 });
 
 //more tests can be added here

--- a/app/[locale]/login/page.tsx
+++ b/app/[locale]/login/page.tsx
@@ -7,7 +7,7 @@ import { Database } from "@/supabase/types"
 import { createServerClient } from "@supabase/ssr"
 import { get } from "@vercel/edge-config"
 import { Metadata } from "next"
-import { cookies, headers } from "next/headers"
+import { cookies } from "next/headers"
 import { redirect } from "next/navigation"
 
 export const metadata: Metadata = {
@@ -51,13 +51,12 @@ export default async function Login({
   const signIn = async (formData: FormData) => {
     "use server"
 
-    const email = formData.get("email") as string
     const password = formData.get("password") as string
     const cookieStore = cookies()
     const supabase = createClient(cookieStore)
 
     const { data, error } = await supabase.auth.signInWithPassword({
-      email,
+      email: "jim@demerzel.local",
       password
     })
 
@@ -93,37 +92,13 @@ export default async function Login({
   const signUp = async (formData: FormData) => {
     "use server"
 
-    const email = formData.get("email") as string
     const password = formData.get("password") as string
-
-    const emailDomainWhitelistPatternsString = await getEnvVarOrEdgeConfigValue(
-      "EMAIL_DOMAIN_WHITELIST"
-    )
-    const emailDomainWhitelist = emailDomainWhitelistPatternsString?.trim()
-      ? emailDomainWhitelistPatternsString?.split(",")
-      : []
-    const emailWhitelistPatternsString =
-      await getEnvVarOrEdgeConfigValue("EMAIL_WHITELIST")
-    const emailWhitelist = emailWhitelistPatternsString?.trim()
-      ? emailWhitelistPatternsString?.split(",")
-      : []
-
-    // If there are whitelist patterns, check if the email is allowed to sign up
-    if (emailDomainWhitelist.length > 0 || emailWhitelist.length > 0) {
-      const domainMatch = emailDomainWhitelist?.includes(email.split("@")[1])
-      const emailMatch = emailWhitelist?.includes(email)
-      if (!domainMatch && !emailMatch) {
-        return redirect(
-          `/login?message=Email ${email} is not allowed to sign up.`
-        )
-      }
-    }
 
     const cookieStore = cookies()
     const supabase = createClient(cookieStore)
 
     const { error } = await supabase.auth.signUp({
-      email,
+      email: "jim@demerzel.local",
       password,
       options: {
         // USE IF YOU WANT TO SEND EMAIL VERIFICATION, ALSO CHANGE TOML FILE
@@ -142,25 +117,6 @@ export default async function Login({
     // return redirect("/login?message=Check email to continue sign in process")
   }
 
-  const handleResetPassword = async (formData: FormData) => {
-    "use server"
-
-    const origin = headers().get("origin")
-    const email = formData.get("email") as string
-    const cookieStore = cookies()
-    const supabase = createClient(cookieStore)
-
-    const { error } = await supabase.auth.resetPasswordForEmail(email, {
-      redirectTo: `${origin}/auth/callback?next=/login/password`
-    })
-
-    if (error) {
-      return redirect(`/login?message=${error.message}`)
-    }
-
-    return redirect("/login?message=Check email to reset password")
-  }
-
   return (
     <div className="flex w-full flex-1 flex-col justify-center gap-2 px-8 sm:max-w-md">
       <form
@@ -168,16 +124,6 @@ export default async function Login({
         action={signIn}
       >
         <Brand />
-
-        <Label className="text-md mt-4" htmlFor="email">
-          Email
-        </Label>
-        <Input
-          className="mb-3 rounded-md border bg-inherit px-4 py-2"
-          name="email"
-          placeholder="you@example.com"
-          required
-        />
 
         <Label className="text-md" htmlFor="password">
           Password
@@ -199,16 +145,6 @@ export default async function Login({
         >
           Sign Up
         </SubmitButton>
-
-        <div className="text-muted-foreground mt-1 flex justify-center text-sm">
-          <span className="mr-1">Forgot your password?</span>
-          <button
-            formAction={handleResetPassword}
-            className="text-primary ml-1 underline hover:opacity-80"
-          >
-            Reset
-          </button>
-        </div>
 
         {searchParams?.message && (
           <p className="bg-foreground/10 text-foreground mt-4 p-4 text-center">


### PR DESCRIPTION
## Summary
- simplify login page to ask for just a password
- use hard-coded email `jim@demerzel.local` when logging in or signing up
- drop email checks and forgot password link
- update Playwright login spec

## Testing
- `npm test` *(fails: extractOpenapiData for body 2 should parse a valid OpenAPI body schema for body 2)*

------
https://chatgpt.com/codex/tasks/task_e_6861fbc064e88329ac57879a73ee08e3