### PR TITLE
Add User type to default user check

### DIFF
--- a/lib/server/ensure-default-user.ts
+++ b/lib/server/ensure-default-user.ts
@@ -1,5 +1,5 @@
 import { Database } from "@/supabase/types"
-import { createClient } from "@supabase/supabase-js"
+import { createClient, User } from "@supabase/supabase-js"
 
 export async function ensureDefaultUser() {
   const supabaseAdmin = createClient<Database>(
@@ -9,30 +9,29 @@ export async function ensureDefaultUser() {
 
   const password = process.env.DEFAULT_USER_PASSWORD || "Seraphine"
 
-const {
-  data: users,
-  error: listError
-} = await supabaseAdmin.auth.admin.listUsers();
+  const { data: users, error: listError } =
+    await supabaseAdmin.auth.admin.listUsers()
 
-if (listError) throw listError;
+  if (listError) throw listError
 
-const existingUser = users.find(u => u.email === "jim@demerzel.local");
+  const existingUser = users.find((u: User) => u.email === "jim@demerzel.local")
 
-if (existingUser) {
-  const { error: updateError } = await supabaseAdmin.auth.admin.updateUserById(
-    existingUser.id,
-    { password }
-  );
-  if (updateError) throw updateError;
-  console.log("✅ Default user password updated.");
-} else {
-  const { data: newUser, error: createError } = await supabaseAdmin.auth.admin.createUser({
-    email: "jim@demerzel.local",
-    password
-  });
-  if (createError) throw createError;
-  console.log("✅ Default user created.");
-}
+  if (existingUser) {
+    const { error: updateError } =
+      await supabaseAdmin.auth.admin.updateUserById(existingUser.id, {
+        password
+      })
+    if (updateError) throw updateError
+    console.log("✅ Default user password updated.")
+  } else {
+    const { data: newUser, error: createError } =
+      await supabaseAdmin.auth.admin.createUser({
+        email: "jim@demerzel.local",
+        password
+      })
+    if (createError) throw createError
+    console.log("✅ Default user created.")
+  }
 
   if (existingUser?.user) {
     const { error } = await supabaseAdmin.auth.admin.updateUserById(


### PR DESCRIPTION
## Summary
- add `User` import from `@supabase/supabase-js`
- type the `existingUser` lookup using `User`

## Testing
- `npm run lint:fix`
- `npm run format:write`
- `npm test` *(fails: should parse a valid OpenAPI body schema for body 2)*

------
https://chatgpt.com/codex/tasks/task_e_6862262a0f408329af21a328de74f2c0