### PR TITLE
Fix default user list data shape

### DIFF
--- a/lib/server/ensure-default-user.ts
+++ b/lib/server/ensure-default-user.ts
@@ -9,12 +9,14 @@ export async function ensureDefaultUser() {
 
   const password = process.env.DEFAULT_USER_PASSWORD || "Seraphine"
 
-  const { data: users, error: listError } =
+  const { data, error: listError } =
     await supabaseAdmin.auth.admin.listUsers()
 
   if (listError) throw listError
 
-  const existingUser = users.find((u: User) => u.email === "jim@demerzel.local")
+  const existingUser = data.users.find(
+    (u: User) => u.email === "jim@demerzel.local"
+  )
 
   if (existingUser) {
     const { error: updateError } =


### PR DESCRIPTION
## Summary
- fix destructured response from `listUsers` in `ensure-default-user`

## Testing
- `npm test` *(fails: jest not found)*
- `npm run lint` *(fails: next not found)*
- `npm run type-check` *(fails: cannot find modules)*

------
https://chatgpt.com/codex/tasks/task_e_68622cbd373c832981525a4f9c5d4467