### PR TITLE
Fix updateUser check in ensure-default-user

### DIFF
--- a/lib/server/ensure-default-user.ts
+++ b/lib/server/ensure-default-user.ts
@@ -35,9 +35,9 @@ export async function ensureDefaultUser() {
     console.log("✅ Default user created.")
   }
 
-  if (existingUser?.user) {
+  if (existingUser) {
     const { error } = await supabaseAdmin.auth.admin.updateUserById(
-      existingUser.user.id,
+      existingUser.id,
       { password }
     )
     console.log("ensureDefaultUser update", error)


### PR DESCRIPTION
## Summary
- fix ID lookup when updating the default user

## Testing
- `npx jest` *(fails: Need to install jest)*

------
https://chatgpt.com/codex/tasks/task_e_68622ef1b91c8329b9179f2a18918689