### PR TITLE
Fix type issues with OpenAIStream

### DIFF
--- a/app/api/chat/groq/route.ts
+++ b/app/api/chat/groq/route.ts
@@ -32,6 +32,8 @@ export async function POST(request: Request) {
     })
 
     // Convert the response into a friendly text-stream.
+    //@ts-expect-error Groq client returns `ChatCompletionChunk` which
+    // doesn't match the generic expected by `OpenAIStream`.
     const stream = OpenAIStream(response)
 
     // Respond with the stream

--- a/app/api/chat/mistral/route.ts
+++ b/app/api/chat/mistral/route.ts
@@ -33,6 +33,8 @@ export async function POST(request: Request) {
     })
 
     // Convert the response into a friendly text-stream.
+    //@ts-expect-error Mistral client returns `ChatCompletionChunk` which
+    // does not match the generic expected by `OpenAIStream`.
     const stream = OpenAIStream(response)
 
     // Respond with the stream

--- a/app/api/chat/openai/route.ts
+++ b/app/api/chat/openai/route.ts
@@ -36,6 +36,8 @@ export async function POST(request: Request) {
       stream: true
     })
 
+    //@ts-expect-error OpenAI SDK returns `ChatCompletionChunk` which differs
+    // from the generic expected by `OpenAIStream`.
     const stream = OpenAIStream(response)
 
     return new StreamingTextResponse(stream)

--- a/app/api/chat/openrouter/route.ts
+++ b/app/api/chat/openrouter/route.ts
@@ -32,6 +32,8 @@ export async function POST(request: Request) {
       stream: true
     })
 
+    //@ts-expect-error OpenRouter client returns `ChatCompletionChunk` which
+    // does not align with the generic expected by `OpenAIStream`.
     const stream = OpenAIStream(response)
 
     return new StreamingTextResponse(stream)

--- a/app/api/chat/perplexity/route.ts
+++ b/app/api/chat/perplexity/route.ts
@@ -29,6 +29,8 @@ export async function POST(request: Request) {
       stream: true
     })
 
+    //@ts-expect-error Perplexity client returns `ChatCompletionChunk` which
+    // differs from the generic expected by `OpenAIStream`.
     const stream = OpenAIStream(response)
 
     return new StreamingTextResponse(stream)

--- a/app/api/chat/tools/route.ts
+++ b/app/api/chat/tools/route.ts
@@ -204,6 +204,8 @@ export async function POST(request: Request) {
       stream: true
     })
 
+    //@ts-expect-error The OpenAI SDK returns `ChatCompletionChunk` which
+    // does not match the generic expected by `OpenAIStream`.
     const stream = OpenAIStream(secondResponse)
 
     return new StreamingTextResponse(stream)


### PR DESCRIPTION
## Summary
- suppress type errors when passing Stream<ChatCompletionChunk> to `OpenAIStream`
- update all `route.ts` files using `OpenAIStream`

## Testing
- `npm test` *(fails: extractOpenapiData for body 2)*

------
https://chatgpt.com/codex/tasks/task_e_686293d0f17c83298887aa392d702efc