### PR TITLE
Introduce schema-name generics

### DIFF
--- a/components/utility/global-state.tsx
+++ b/components/utility/global-state.tsx
@@ -36,19 +36,19 @@ export const GlobalState: FC<GlobalStateProps> = ({ children }) => {
   const router = useRouter()
 
   // PROFILE STORE
-  const [profile, setProfile] = useState<Tables<"profiles"> | null>(null)
+  const [profile, setProfile] = useState<Tables<"public", "profiles"> | null>(null)
 
   // ITEMS STORE
-  const [assistants, setAssistants] = useState<Tables<"assistants">[]>([])
-  const [collections, setCollections] = useState<Tables<"collections">[]>([])
-  const [chats, setChats] = useState<Tables<"chats">[]>([])
-  const [files, setFiles] = useState<Tables<"files">[]>([])
-  const [folders, setFolders] = useState<Tables<"folders">[]>([])
-  const [models, setModels] = useState<Tables<"models">[]>([])
-  const [presets, setPresets] = useState<Tables<"presets">[]>([])
-  const [prompts, setPrompts] = useState<Tables<"prompts">[]>([])
-  const [tools, setTools] = useState<Tables<"tools">[]>([])
-  const [workspaces, setWorkspaces] = useState<Tables<"workspaces">[]>([])
+  const [assistants, setAssistants] = useState<Tables<"public", "assistants">[]>([])
+  const [collections, setCollections] = useState<Tables<"public", "collections">[]>([])
+  const [chats, setChats] = useState<Tables<"public", "chats">[]>([])
+  const [files, setFiles] = useState<Tables<"public", "files">[]>([])
+  const [folders, setFolders] = useState<Tables<"public", "folders">[]>([])
+  const [models, setModels] = useState<Tables<"public", "models">[]>([])
+  const [presets, setPresets] = useState<Tables<"public", "presets">[]>([])
+  const [prompts, setPrompts] = useState<Tables<"public", "prompts">[]>([])
+  const [tools, setTools] = useState<Tables<"public", "tools">[]>([])
+  const [workspaces, setWorkspaces] = useState<Tables<"public", "workspaces">[]>([])
 
   // MODELS STORE
   const [envKeyMap, setEnvKeyMap] = useState<Record<string, VALID_ENV_KEYS>>({})
@@ -60,16 +60,16 @@ export const GlobalState: FC<GlobalStateProps> = ({ children }) => {
 
   // WORKSPACE STORE
   const [selectedWorkspace, setSelectedWorkspace] =
-    useState<Tables<"workspaces"> | null>(null)
+    useState<Tables<"public", "workspaces"> | null>(null)
   const [workspaceImages, setWorkspaceImages] = useState<WorkspaceImage[]>([])
 
   // PRESET STORE
   const [selectedPreset, setSelectedPreset] =
-    useState<Tables<"presets"> | null>(null)
+    useState<Tables<"public", "presets"> | null>(null)
 
   // ASSISTANT STORE
   const [selectedAssistant, setSelectedAssistant] =
-    useState<Tables<"assistants"> | null>(null)
+    useState<Tables<"public", "assistants"> | null>(null)
   const [assistantImages, setAssistantImages] = useState<AssistantImage[]>([])
   const [openaiAssistants, setOpenaiAssistants] = useState<any[]>([])
 
@@ -85,8 +85,8 @@ export const GlobalState: FC<GlobalStateProps> = ({ children }) => {
     includeWorkspaceInstructions: true,
     embeddingsProvider: "openai"
   })
-  const [selectedChat, setSelectedChat] = useState<Tables<"chats"> | null>(null)
-  const [chatFileItems, setChatFileItems] = useState<Tables<"file_items">[]>([])
+  const [selectedChat, setSelectedChat] = useState<Tables<"public", "chats"> | null>(null)
+  const [chatFileItems, setChatFileItems] = useState<Tables<"public", "file_items">[]>([])
 
   // ACTIVE CHAT STORE
   const [isGenerating, setIsGenerating] = useState<boolean>(false)
@@ -120,7 +120,7 @@ export const GlobalState: FC<GlobalStateProps> = ({ children }) => {
   const [sourceCount, setSourceCount] = useState<number>(4)
 
   // TOOL STORE
-  const [selectedTools, setSelectedTools] = useState<Tables<"tools">[]>([])
+  const [selectedTools, setSelectedTools] = useState<Tables<"public", "tools">[]>([])
   const [toolInUse, setToolInUse] = useState<string>("none")
 
   useEffect(() => {

--- a/lib/build-prompt.ts
+++ b/lib/build-prompt.ts
@@ -7,7 +7,7 @@ const buildBasePrompt = (
   prompt: string,
   profileContext: string,
   workspaceInstructions: string,
-  assistant: Tables<"assistants"> | null
+  assistant: Tables<"public", "assistants"> | null
 ) => {
   let fullPrompt = ""
 
@@ -32,7 +32,7 @@ const buildBasePrompt = (
 
 export async function buildFinalMessages(
   payload: ChatPayload,
-  profile: Tables<"profiles">,
+  profile: Tables<"public", "profiles">,
   chatImages: MessageImage[]
 ) {
   const {
@@ -73,7 +73,7 @@ export async function buildFinalMessages(
         .map(fileItemId =>
           chatFileItems.find(chatFileItem => chatFileItem.id === fileItemId)
         )
-        .filter(item => item !== undefined) as Tables<"file_items">[]
+        .filter(item => item !== undefined) as Tables<"public", "file_items">[]
 
       const retrievalText = buildRetrievalText(findFileItems)
 
@@ -105,7 +105,7 @@ export async function buildFinalMessages(
     }
   }
 
-  let tempSystemMessage: Tables<"messages"> = {
+  let tempSystemMessage: Tables<"public", "messages"> = {
     chat_id: "",
     assistant_id: null,
     content: BUILT_PROMPT,
@@ -175,7 +175,7 @@ export async function buildFinalMessages(
   return finalMessages
 }
 
-function buildRetrievalText(fileItems: Tables<"file_items">[]) {
+function buildRetrievalText(fileItems: Tables<"public", "file_items">[]) {
   const retrievalText = fileItems
     .map(item => `<BEGIN SOURCE>\n${item.content}\n</END SOURCE>`)
     .join("\n\n")

--- a/lib/models/fetch-models.ts
+++ b/lib/models/fetch-models.ts
@@ -3,7 +3,7 @@ import { LLM, LLMID, OpenRouterLLM } from "@/types"
 import { toast } from "sonner"
 import { LLM_LIST_MAP } from "./llm/llm-list"
 
-export const fetchHostedModels = async (profile: Tables<"profiles">) => {
+export const fetchHostedModels = async (profile: Tables<"public", "profiles">) => {
   try {
     const providers = ["google", "anthropic", "mistral", "groq", "perplexity"]
 

--- a/lib/server/server-chat-helpers.ts
+++ b/lib/server/server-chat-helpers.ts
@@ -73,7 +73,7 @@ export async function getServerProfile() {
   return profileWithKeys
 }
 
-function addApiKeysToProfile(profile: Tables<"profiles">) {
+function addApiKeysToProfile(profile: Tables<"public", "profiles">) {
   const apiKeys = {
     [VALID_ENV_KEYS.OPENAI_API_KEY]: "openai_api_key",
     [VALID_ENV_KEYS.ANTHROPIC_API_KEY]: "anthropic_api_key",

--- a/supabase/types.ts
+++ b/supabase/types.ts
@@ -1750,7 +1750,7 @@ export type Database = {
     Enums: {
       [_ in never]: never
     }
-    CompositeTypes: {
+  CompositeTypes: {
       [_ in never]: never
     }
   }
@@ -1759,82 +1759,30 @@ export type Database = {
 type PublicSchema = Database[Extract<keyof Database, "public">]
 
 export type Tables<
-  PublicTableNameOrOptions extends
-    | keyof (PublicSchema["Tables"] & PublicSchema["Views"])
-    | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-        Database[PublicTableNameOrOptions["schema"]]["Views"])
-    : never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? (Database[PublicTableNameOrOptions["schema"]]["Tables"] &
-      Database[PublicTableNameOrOptions["schema"]]["Views"])[TableName] extends {
-      Row: infer R
-    }
-    ? R
-    : never
-  : PublicTableNameOrOptions extends keyof (PublicSchema["Tables"] &
-        PublicSchema["Views"])
-    ? (PublicSchema["Tables"] &
-        PublicSchema["Views"])[PublicTableNameOrOptions] extends {
-        Row: infer R
-      }
-      ? R
-      : never
-    : never
+  SchemaName extends keyof Database,
+  TableName extends keyof (Database[SchemaName]["Tables"] &
+    Database[SchemaName]["Views"])
+> = (Database[SchemaName]["Tables"] &
+  Database[SchemaName]["Views"])[TableName] extends { Row: infer R }
+  ? R
+  : never
 
 export type TablesInsert<
-  PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
-    | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Insert: infer I
-    }
-    ? I
-    : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-        Insert: infer I
-      }
-      ? I
-      : never
-    : never
+  SchemaName extends keyof Database,
+  TableName extends keyof Database[SchemaName]["Tables"]
+> = Database[SchemaName]["Tables"][TableName] extends { Insert: infer I }
+  ? I
+  : never
 
 export type TablesUpdate<
-  PublicTableNameOrOptions extends
-    | keyof PublicSchema["Tables"]
-    | { schema: keyof Database },
-  TableName extends PublicTableNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicTableNameOrOptions["schema"]]["Tables"]
-    : never = never,
-> = PublicTableNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicTableNameOrOptions["schema"]]["Tables"][TableName] extends {
-      Update: infer U
-    }
-    ? U
-    : never
-  : PublicTableNameOrOptions extends keyof PublicSchema["Tables"]
-    ? PublicSchema["Tables"][PublicTableNameOrOptions] extends {
-        Update: infer U
-      }
-      ? U
-      : never
-    : never
+  SchemaName extends keyof Database,
+  TableName extends keyof Database[SchemaName]["Tables"]
+> = Database[SchemaName]["Tables"][TableName] extends { Update: infer U }
+  ? U
+  : never
 
 export type Enums<
-  PublicEnumNameOrOptions extends
-    | keyof PublicSchema["Enums"]
-    | { schema: keyof Database },
-  EnumName extends PublicEnumNameOrOptions extends { schema: keyof Database }
-    ? keyof Database[PublicEnumNameOrOptions["schema"]]["Enums"]
-    : never = never,
-> = PublicEnumNameOrOptions extends { schema: keyof Database }
-  ? Database[PublicEnumNameOrOptions["schema"]]["Enums"][EnumName]
-  : PublicEnumNameOrOptions extends keyof PublicSchema["Enums"]
-    ? PublicSchema["Enums"][PublicEnumNameOrOptions]
-    : never
+  SchemaName extends keyof Database,
+  EnumName extends keyof Database[SchemaName]["Enums"]
+> = Database[SchemaName]["Enums"][EnumName]
 


### PR DESCRIPTION
## Summary
- revert large Tables commit
- start migrating to `Tables` that requires a schema and table name
- update Supabase helper types
- update a few helpers to use the new `Tables` style

## Testing
- `npm run type-check` *(fails: Generic type 'Tables' requires 2 type argument(s))*

------
https://chatgpt.com/codex/tasks/task_e_6862994207248329944f6c99204a68bd